### PR TITLE
fix(thermostat): correct handling of auto mode as per Homebridge spec

### DIFF
--- a/src/accessories/thermostat.ts
+++ b/src/accessories/thermostat.ts
@@ -189,7 +189,7 @@ export class ThermostatAccessory {
         );
         break;
       case 'mode':
-        const mode = this.toCurrentHeatingCoolingStateCharacteristic(
+        const mode = this.toTargetHeatingCoolingStateCharacteristic(
           event.last_read_state as ThermostatMode
         );
         let actualMode = mode;

--- a/src/accessories/thermostat.ts
+++ b/src/accessories/thermostat.ts
@@ -220,6 +220,17 @@ export class ThermostatAccessory {
           mode
         );
         break;
+      case 'cooling_setpoint':
+        const coolingSetpoint = this.toTemperatureCharacteristic(
+          Number(event.last_read_state)
+        );
+        this.state.cooling_threshold_temperature.current = coolingSetpoint;
+        this.state.cooling_threshold_temperature.target = coolingSetpoint;
+        this.thermostatService.updateCharacteristic(
+          this.platform.Characteristic.CoolingThresholdTemperature,
+          coolingSetpoint
+        );
+        break;
       case 'heating_setpoint':
         const heatingSetpoint = this.toTemperatureCharacteristic(
           Number(event.last_read_state)

--- a/src/accessories/thermostat.ts
+++ b/src/accessories/thermostat.ts
@@ -192,26 +192,32 @@ export class ThermostatAccessory {
         const mode = this.toCurrentHeatingCoolingStateCharacteristic(
           event.last_read_state as ThermostatMode
         );
-        this.state.heating_cooling_state.current = mode;
+        let actualMode = mode;
+        if (mode === this.platform.Characteristic.TargetHeatingCoolingState.AUTO) {
+          // Determine if heating or cooling based on target and current temperature
+          if (
+            this.state.target_temperature.current <
+            this.state.current_temperature.current
+          ) {
+            actualMode = this.platform.Characteristic.CurrentHeatingCoolingState.COOL;
+          } else if (
+            this.state.target_temperature.current >
+            this.state.current_temperature.current
+          ) {
+            actualMode = this.platform.Characteristic.CurrentHeatingCoolingState.HEAT;
+          } else {
+            actualMode = this.platform.Characteristic.CurrentHeatingCoolingState.OFF;
+          }
+        }
+        this.state.heating_cooling_state.current = actualMode;
         this.state.heating_cooling_state.target = mode;
         this.thermostatService.updateCharacteristic(
           this.platform.Characteristic.CurrentHeatingCoolingState,
-          mode
+          actualMode
         );
         this.thermostatService.updateCharacteristic(
           this.platform.Characteristic.TargetHeatingCoolingState,
           mode
-        );
-        break;
-      case 'cooling_setpoint':
-        const coolingSetpoint = this.toTemperatureCharacteristic(
-          Number(event.last_read_state)
-        );
-        this.state.cooling_threshold_temperature.current = coolingSetpoint;
-        this.state.cooling_threshold_temperature.target = coolingSetpoint;
-        this.thermostatService.updateCharacteristic(
-          this.platform.Characteristic.CoolingThresholdTemperature,
-          coolingSetpoint
         );
         break;
       case 'heating_setpoint':
@@ -256,8 +262,6 @@ export class ThermostatAccessory {
         return this.platform.Characteristic.CurrentHeatingCoolingState.COOL;
       case 'heat':
         return this.platform.Characteristic.CurrentHeatingCoolingState.HEAT;
-      case 'auto':
-        return this.platform.Characteristic.TargetHeatingCoolingState.AUTO;
       default:
         return this.platform.Characteristic.TargetHeatingCoolingState.OFF;
     }


### PR DESCRIPTION
This fixes the error `CurrentHeatingCoolingState returns invalid value 3`

According to the [Homebridge specification](https://developers.homebridge.io/#/characteristic/CurrentHeatingCoolingState), the "CurrentHeatingCoolingState" characteristic should return one of three values - 0, 1, or 2, each representing "off", "heating", or "cooling". But when the thermostat is set to "auto" mode, it should respond with the status that's really in operation, not just echo the "auto" setting.

In other words, when the TARGET is set to AUTO, the accessory makes its own decision, based on the present and desired temperatures, about whether the CURRENT state should be "heating", "cooling", or "off". Consequently, the "auto" state doesn't directly correspond to a particular operational mode, but rather serves as a conditional setting that allows the thermostat to decide the CURRENT state on its own